### PR TITLE
fix!: Add the many2one in update form

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "streamlit-sqlalchemy"
-version = "0.1.1"
+version = "0.2.0"
 authors = [{ name = "artygo8", email = "arthurgossuin@gmail.com" }]
 description = "Some templating for streamlit and sqlalchemy"
 readme = "README.md"

--- a/src/streamlit_sqlalchemy/mixin.py
+++ b/src/streamlit_sqlalchemy/mixin.py
@@ -22,8 +22,7 @@ class DeclarativeBaseWithId(DeclarativeBase):
 
 
 class InputFunction(Protocol):
-    def __call__(self, label: str, value: Any | None = None) -> Any:
-        ...
+    def __call__(self, label: str, value: Any | None = None) -> Any: ...
 
 
 def _st_pretty_class_name(cls: type[DeclarativeBase]) -> str:
@@ -327,10 +326,14 @@ class StreamlitAlchemyMixin(mixin_parent):
             choices.sort(key=_st_order_by)
 
             def selectbox(label, value=None):
-                # we don't want to use the default value here
+                index = None
+                if value is not None:
+                    # value should be an id
+                    index = next(choices.index(c) for c in choices if c.id == value)
+
                 return st.selectbox(
                     label,
-                    index=None,
+                    index=index,
                     options=choices,
                     format_func=_st_repr,
                 )
@@ -543,7 +546,7 @@ class StreamlitAlchemyMixin(mixin_parent):
                 for column in self.__table__.columns
             }
             for column in self.__table__.columns:
-                if column.name == "id" or column.name.endswith("_id"):
+                if column.name == "id":
                     continue
 
                 if column.name in except_columns:

--- a/tests/streamlit_sqlalchemy/mixin/update_form.py
+++ b/tests/streamlit_sqlalchemy/mixin/update_form.py
@@ -1,0 +1,7 @@
+from tests.objects import OneToMany, Item
+
+item = next(i for i in Item.st_list_all())
+item.st_update_form()
+
+for o2m in OneToMany.st_list_all():
+    o2m.st_update_form()

--- a/tests/streamlit_sqlalchemy/mixin/update_form_except_m2o.py
+++ b/tests/streamlit_sqlalchemy/mixin/update_form_except_m2o.py
@@ -1,0 +1,7 @@
+from tests.objects import OneToMany, Item
+
+item = next(i for i in Item.st_list_all())
+item.st_update_form()
+
+for o2m in OneToMany.st_list_all():
+    o2m.st_update_form(except_columns=["test_item_id"])

--- a/tests/streamlit_sqlalchemy/test_mixin.py
+++ b/tests/streamlit_sqlalchemy/test_mixin.py
@@ -133,6 +133,58 @@ def test_update_select_form_one_item(database):
     assert len(at.button) == 0
 
 
+def test_update_form_one_item(database):
+    # create item
+    Item._st_create(name="A", count=1)
+    Item._st_create(name="C", count=2)
+    Item._st_create(name="B", count=3)
+    database.session.commit()
+    first_item = next(i for i in Item.st_list_all() if i.name == "B")  # type: ignore
+    OneToMany._st_create(first_field="FF", test_item_id=first_item.id)
+
+    at = AppTest.from_file(
+        "tests/streamlit_sqlalchemy/mixin/update_form.py",
+        default_timeout=10,
+    ).run(timeout=10)
+
+    # first form
+    assert at.text_input[0].label == "Name"
+    assert at.number_input[0].label == "Count"
+    assert at.button[0].label == "Update Item"
+
+    # second form
+    assert at.text_input[1].label == "First Field"
+    assert at.selectbox[0].label == "Test Item"
+    assert at.selectbox[0].options == ["A", "B", "C"]
+    assert at.selectbox[0].value.name == "B"  # type: ignore
+    assert at.button[1].label == "Update One To Many"
+
+
+def test_update_form_one_item_except_m2o(database):
+    # create item
+    Item._st_create(name="A", count=1)
+    Item._st_create(name="C", count=2)
+    Item._st_create(name="B", count=3)
+    database.session.commit()
+    first_item = next(i for i in Item.st_list_all() if i.name == "B")  # type: ignore
+    OneToMany._st_create(first_field="FF", test_item_id=first_item.id)
+
+    at = AppTest.from_file(
+        "tests/streamlit_sqlalchemy/mixin/update_form_except_m2o.py",
+        default_timeout=10,
+    ).run(timeout=10)
+
+    # first form
+    assert at.text_input[0].label == "Name"
+    assert at.number_input[0].label == "Count"
+    assert at.button[0].label == "Update Item"
+
+    # second form
+    assert at.text_input[1].label == "First Field"
+    assert len(at.selectbox) == 0
+    assert at.button[1].label == "Update One To Many"
+
+
 def test_update_select_form_several_items(database):
     # create item
     Item._st_create(name="A", count=1)


### PR DESCRIPTION
fix!: Add the many2one in update form

Originally, the many2one were not added to the update form because of
my single usecase. However it absolutely makes sense to be able to
modify the many2one relationships.

To keep the original behiaviour, you can use the `except_columns`
kwarg and add each of the `_id` ending fields.

BREAKING CHANGE: Now you have the many2one by default in the update
form.

Refs: https://github.com/artygo8/streamlit-sqlalchemy/issues/3