### PR TITLE
fix: except_column failing with foreign keys

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "streamlit-sqlalchemy"
-version = "0.2.2"
+version = "0.2.3"
 authors = [{ name = "artygo8", email = "arthurgossuin@gmail.com" }]
 description = "Some templating for streamlit and sqlalchemy"
 readme = "README.md"

--- a/src/streamlit_sqlalchemy/mixin.py
+++ b/src/streamlit_sqlalchemy/mixin.py
@@ -225,6 +225,7 @@ class StreamlitAlchemyMixin(mixin_parent):
             format_func=lambda obj: _st_repr(obj),
         )
         if selected_obj_to_update:
+            selected_obj_to_update: cls
             if selected_obj_to_update.st_update_form(
                 except_columns=except_columns, border=border
             ):
@@ -576,7 +577,7 @@ class StreamlitAlchemyMixin(mixin_parent):
 
             submitted = st.form_submit_button(f"Update {self.st_pretty_class()}")
             if submitted:
-                for field in kwargs:
+                for field in set(kwargs) - set(except_columns):
                     if field.endswith("_id"):
                         kwargs[field] = kwargs[field].id
                 self._st_update(**kwargs)


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/agossuin/.local/lib/python3.10/site-packages/streamlit/runtime/scriptrunner/script_runner.py", line 600, in _run_script
    exec(code, module.__dict__)
File "/home/agossuin/...", line 42, in my_class_view
    MyClass.st_crud_tabs(
  File "/home/agossuin/.local/lib/python3.10/site-packages/streamlit_sqlalchemy/mixin.py", line 288, in st_crud_tabs
    cls.st_update_select_form(
  File "/home/agossuin/.local/lib/python3.10/site-packages/streamlit_sqlalchemy/mixin.py", line 228, in st_update_select_form
    if selected_obj_to_update.st_update_form(
  File "/home/agossuin/.local/lib/python3.10/site-packages/streamlit_sqlalchemy/mixin.py", line 582, in st_update_form
    kwargs[field] = kwargs[field].id
AttributeError: 'int' object has no attribute 'id'
```

+ small typehinting addition