### PR TITLE
fix: allow using None for foreign keys

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "streamlit-sqlalchemy"
-version = "0.2.3"
+version = "0.2.4"
 authors = [{ name = "artygo8", email = "arthurgossuin@gmail.com" }]
 description = "Some templating for streamlit and sqlalchemy"
 readme = "README.md"

--- a/src/streamlit_sqlalchemy/mixin.py
+++ b/src/streamlit_sqlalchemy/mixin.py
@@ -578,7 +578,7 @@ class StreamlitAlchemyMixin(mixin_parent):
             submitted = st.form_submit_button(f"Update {self.st_pretty_class()}")
             if submitted:
                 for field in set(kwargs) - set(except_columns):
-                    if field.endswith("_id"):
+                    if field.endswith("_id") and kwargs[field]:
                         kwargs[field] = kwargs[field].id
                 self._st_update(**kwargs)
         return submitted


### PR DESCRIPTION
```
AttributeError: 'NoneType' object has no attribute 'id'
```

If it were to fail, it should be on the DB side, not in the library.