### PR TITLE
fix: pin down dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Operating System :: OS Independent",
 ]
-dependencies = ["streamlit>=1.29.0", "sqlalchemy"]
+dependencies = ["streamlit>=1.29.0,<1.53.0", "sqlalchemy"]
 license = "Apache-2.0"
 keywords = ["streamlit", "sqlalchemy", "templating", "sql", "database"]
 


### PR DESCRIPTION
A change in the way the tabs are handled totally broke the package. Upon selection in a tab, nothing happens.

There was already an issue where upon select in a tab, the focus would go back to the first tab. I guess they fixed that one...

Issue: #12